### PR TITLE
Add test for '#' character in string literals

### DIFF
--- a/test/corpus/strings.scm
+++ b/test/corpus/strings.scm
@@ -112,3 +112,19 @@ several lines'''
       (assignment_operator)
       (expression
         (string_literal)))))
+
+================================================================================
+Comments in strings
+================================================================================
+x = 'abc#def'
+
+--------------------------------------------------------------------------------
+
+(build_definition
+  (statement
+    (assignment_statement
+      (expression
+        (identifier))
+      (assignment_operator)
+      (expression
+        (string_literal)))))


### PR DESCRIPTION
Related to #2.

The test to be added currently doesn't pass, because the current behavior is incorrect.

I have tried to fix this, but I lack experience with tree-sitter and javascript to do so. I have found https://github.com/tree-sitter/tree-sitter/issues/1087 which appears to be highly relevant here.